### PR TITLE
Filter trackers in/not in exodus in the administration page

### DIFF
--- a/etip/trackers/admin.py
+++ b/etip/trackers/admin.py
@@ -6,7 +6,10 @@ from trackers.models import Tracker, Capability, Advertising, Analytic, Network
 
 @admin.register(Tracker)
 class TrackerModelAdmin(VersionAdmin):
-    pass
+    date_hierarchy = 'created'
+    search_fields = ['name']
+    list_display = ('name', 'code_signature', 'is_in_exodus')
+    list_filter = ('is_in_exodus',)
 
 
 @admin.register(Capability)

--- a/etip/trackers/templates/base.html
+++ b/etip/trackers/templates/base.html
@@ -18,7 +18,7 @@
             font-size : 1.1em;
         }
     </style>
-    <title>εxodus</title>
+    <title>ETIP - εxodus</title>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg sticky-top navbar-dark bg-dark">

--- a/etip/trackers/templates/base.html
+++ b/etip/trackers/templates/base.html
@@ -25,6 +25,10 @@
     <a class="navbar-brand" href="/">
         <span class="h2">εxodus</span> <span class="small text-muted">ETIP v1.0</span>
     </a>
+    <div class="ml-auto">
+        <a class="btn btn-light btn-sm" href="/admin" role="button">Admin</a>
+        <a class="btn btn-light btn-sm" href="https://github.com/Exodus-Privacy/etip/" role="button">GitHub</a>
+    </div>
 </nav>
 <br>
 <div class="container-fluid">


### PR DESCRIPTION
Change logs:
- Added few features to the trackers admin page: created date hierarchy, name search, filter by "is_in_exodus" (see screenshot 1). Fixes #7 
- Added buttons for "Admin" and "Github" on the right side of the navigation bar (see screenshot 2). Fixes #5 
- Changed HTML title tag to "ETIP - εxodus" instead of "εxodus". Fixes #10 

Comments are welcome :).

**Screenshot 1:**
![image](https://user-images.githubusercontent.com/6069449/53670562-74d0dd80-3c7b-11e9-841d-f790b33781e5.png)

**Screenshot 2:**
![image](https://user-images.githubusercontent.com/6069449/53670574-82866300-3c7b-11e9-8a5d-3dd7a7bd46c1.png)
