### PR TITLE
feat(export_trackers): json of all trackers

### DIFF
--- a/etip/trackers/models.py
+++ b/etip/trackers/models.py
@@ -40,6 +40,9 @@ class Tracker(models.Model):
     MIN_DESCRIPTION_SIZE = 180
     MIN_SHORT_DESCRIPTION_SIZE = 180
     MIN_WEBSITE_SIZE = 3
+    EXPORTABLE_FIELDS = [
+        'name', 'code_signature', 'network_signature', 'website'
+    ]
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created = models.DateTimeField(auto_now_add=True)

--- a/etip/trackers/templates/tracker_list.html
+++ b/etip/trackers/templates/tracker_list.html
@@ -6,6 +6,7 @@
             <div class="alert bg-light">
                 <div class="alert-heading">
                     <h4><span class="badge badge-info">{{ count }}</span> tracker{{ count|pluralize }}</h4>
+                    <a href="{%url 'trackers:export'%}">Export as JSON</a>
                 </div>
                 <table class="table table-hover table-responsive">
                     <thead class="">

--- a/etip/trackers/urls.py
+++ b/etip/trackers/urls.py
@@ -5,5 +5,5 @@ from . import views
 app_name = 'trackers'
 urlpatterns = [
     url(r'^$', views.index, name='index'),
-    # url(r'^(?P<tracker_id>[0-9]+)/$', views.detail, name = 'detail'),
+    url(r'^trackers/export$', views.export_tracker_list, name='export')
 ]

--- a/etip/trackers/views.py
+++ b/etip/trackers/views.py
@@ -1,3 +1,4 @@
+from django.http import JsonResponse
 from django.http.response import Http404
 from django.core.paginator import Paginator
 from django.shortcuts import render
@@ -20,3 +21,11 @@ def index(request):
         'trackers': trackers,
         'count': count
     })
+
+
+def export_tracker_list(request):
+    trackers = Tracker.objects.order_by('name')
+    trackers_list = list(trackers.values(*Tracker.EXPORTABLE_FIELDS))
+    response = JsonResponse(dict(trackers=trackers_list))
+    response['Content-Disposition'] = 'attachment; filename=trackers.json'
+    return response


### PR DESCRIPTION
A JSON file can be downloaded with all trackers name, code signature, network signature and website from the trackers list main page. 

JSON file structure : 

```
{
  "trackers": [
    {
      "name": "tracker name",
      "code_signature": "tracker code signature", 
      "network_signature": "tracker network signature",
      "website": "tracker website"
    }
  ]
}
```

Don't hesitate if there are things to change ! :)

Fixes #11 