### PR TITLE
feat(trackers): add search by name

### DIFF
--- a/etip/trackers/templates/tracker_list.html
+++ b/etip/trackers/templates/tracker_list.html
@@ -2,6 +2,14 @@
 {% block content %}
     <div class="row justify-content-md-center">
         <div class="col-lg-12">
+            <form class="form-inline" method="get">
+                <label class="sr-only" for="inlineFormTrackerName">Tracker name:</label>
+                <input type="text" class="form-control mb-2 mr-2 col-3" name="q" id="inlineFormTrackerName" placeholder="Tracker name">
+                <button type="submit" class="btn btn-primary mb-2 mr-2">Submit</button>
+                <a class="btn btn-info mb-2" href={%url 'trackers:index'%}>Clean filter</a>
+            </form>
+        </div>
+        <div class="col-lg-12">
         {% if trackers %}
             <div class="alert bg-light">
                 <div class="alert-heading">

--- a/etip/trackers/templates/tracker_list.html
+++ b/etip/trackers/templates/tracker_list.html
@@ -4,9 +4,9 @@
         <div class="col-lg-12">
             <form class="form-inline" method="get">
                 <label class="sr-only" for="inlineFormTrackerName">Tracker name:</label>
-                <input type="text" class="form-control mb-2 mr-2 col-3" name="q" id="inlineFormTrackerName" placeholder="Tracker name">
+                <input type="text" class="form-control mb-2 mr-2 col-3" value="{{ filter_name }}" name="tracker_name" id="inlineFormTrackerName" placeholder="Tracker name">
                 <button type="submit" class="btn btn-primary mb-2 mr-2">Submit</button>
-                <a class="btn btn-info mb-2" href={%url 'trackers:index'%}>Clean filter</a>
+                <a class="btn btn-info mb-2" href={%url 'trackers:index'%}>Clear filter</a>
             </form>
         </div>
         <div class="col-lg-12">

--- a/etip/trackers/templates/tracker_list.html
+++ b/etip/trackers/templates/tracker_list.html
@@ -1,4 +1,5 @@
 {% extends "base.html"%}
+{% load url_replace %}
 {% block content %}
     <div class="row justify-content-md-center">
         <div class="col-lg-12">
@@ -119,8 +120,8 @@
                 <div>
                     <ul class="pagination pagination-sm justify-content-center">
                         {% if trackers.has_previous %}
-                        <li class="page-item"><a class="page-link" href="?page=1">First</a></li>
-                        <li class="page-item"><a class="page-link" href="?page={{ trackers.previous_page_number }}">Previous</a></li>
+                        <li class="page-item"><a class="page-link" href="?{% url_replace 'page' 1 %}">First</a></li>
+                        <li class="page-item"><a class="page-link" href="?{% url_replace 'page' trackers.previous_page_number %}">Previous</a></li>
                         {% else %}
                         <li class="page-item disabled"><a class="page-link" href="#">First</a></li>
                         <li class="page-item disabled"><a class="page-link" href="#">Previous</a></li>
@@ -128,15 +129,15 @@
                         {% for i in trackers.paginator.page_range %}
                             {% if i > trackers.number|add:'-5' and i < trackers.number|add:'5' %}
                                 {% if i == trackers.number %}
-                                <li class="page-item active"> <a class="page-link" href="?page={{ i }}">{{ i }}</a> </li>
+                                <li class="page-item active"> <a class="page-link" href="?{% url_replace 'page' i %}">{{ i }}</a> </li>
                                 {% else %}
-                                <li class="page-item"> <a class="page-link" href="?page={{ i }}">{{ i }}</a> </li>
+                                <li class="page-item"> <a class="page-link" href="?{% url_replace 'page' i %}">{{ i }}</a> </li>
                                 {% endif %}
                             {% endif %}
                         {% endfor %}
                         {% if trackers.has_next %}
-                        <li class="page-item"><a class="page-link" href="?page={{ trackers.next_page_number }}">&nbsp&nbspNext&nbsp&nbsp</a></li>
-                        <li class="page-item"><a class="page-link" href="?page={{ trackers.paginator.num_pages }}">Last&nbsp</a></li>
+                        <li class="page-item"><a class="page-link" href="?{% url_replace 'page' trackers.next_page_number %}">&nbsp&nbspNext&nbsp&nbsp</a></li>
+                        <li class="page-item"><a class="page-link" href="?{% url_replace 'page' trackers.paginator.num_pages %}">Last&nbsp</a></li>
                         {% else %}
                         <li class="page-item disabled"><a class="page-link" href="#">&nbsp&nbspNext&nbsp&nbsp</a></li>
                         <li class="page-item disabled"><a class="page-link" href="">Last&nbsp</a></li>

--- a/etip/trackers/templatetags/url_replace.py
+++ b/etip/trackers/templatetags/url_replace.py
@@ -1,0 +1,13 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def url_replace(context, field, value):
+    """
+    Utility function to replace the value of a specified parameter in URL
+    """
+    get_dict = context['request'].GET.copy()
+    get_dict[field] = value
+    return get_dict.urlencode()

--- a/etip/trackers/tests.py
+++ b/etip/trackers/tests.py
@@ -204,6 +204,56 @@ class TrackerModelTests(TestCase):
         self.assertEquals(tracker.missing_fields(), expected_output)
 
 
+class IndexTrackerListViewTests(TestCase):
+    def test_with_trackers(self):
+        tracker_1 = Tracker(
+            name='name_tracker_1',
+            code_signature='code_1',
+            network_signature='network_1',
+            website='https://website1'
+        )
+        tracker_2 = Tracker(
+            name='random name',
+            code_signature='code_2',
+            network_signature='network_2',
+            website='https://website2',
+        )
+
+        tracker_1.save()
+        tracker_2.save()
+
+        c = Client()
+        response = c.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, tracker_1.name, 1)
+        self.assertContains(response, tracker_2.name, 1)
+        self.assertEqual(response.context['count'], 2)
+
+    def test_with_search_query_with_results(self):
+        tracker_1 = Tracker(
+            name='name_tracker_1',
+            code_signature='code_1',
+            network_signature='network_1',
+            website='https://website1'
+        )
+        tracker_2 = Tracker(
+            name='random name',
+            code_signature='tracker_code_2',
+            network_signature='network_2',
+            website='https://website2',
+        )
+
+        tracker_1.save()
+        tracker_2.save()
+
+        c = Client()
+        response = c.get('/', {'q': 'tracker'})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, tracker_1.name, 1)
+        self.assertNotContains(response, tracker_2.name)
+        self.assertEqual(response.context['count'], 1)
+
+
 class ExportTrackerListViewTests(TestCase):
     def test_without_trackers(self):
         c = Client()

--- a/etip/trackers/tests.py
+++ b/etip/trackers/tests.py
@@ -231,7 +231,7 @@ class IndexTrackerListViewTests(TestCase):
 
     def test_with_search_query_with_results(self):
         tracker_1 = Tracker(
-            name='name_tracker_1',
+            name='match_name_tracker_1',
             code_signature='code_1',
             network_signature='network_1',
             website='https://website1'
@@ -247,11 +247,29 @@ class IndexTrackerListViewTests(TestCase):
         tracker_2.save()
 
         c = Client()
-        response = c.get('/', {'q': 'tracker'})
+        response = c.get('/', {'tracker_name': 'match'})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, tracker_1.name, 1)
         self.assertNotContains(response, tracker_2.name)
         self.assertEqual(response.context['count'], 1)
+
+    def test_with_results_and_paginate(self):
+        for i in range(0, 25):
+            Tracker(
+                name='AcTracker_name'
+            ).save()
+
+        for i in range(0, 10):
+            Tracker(
+                name='AbTracker_name'
+            ).save()
+
+        c = Client()
+        response = c.get('/', {'tracker_name': 'Ac', 'page': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Ab')
+        self.assertEqual(response.context['count'], 25)
+        self.assertEqual(len(response.context['trackers']), 5)
 
 
 class ExportTrackerListViewTests(TestCase):

--- a/etip/trackers/views.py
+++ b/etip/trackers/views.py
@@ -8,9 +8,14 @@ from trackers.models import Tracker
 
 def index(request):
     try:
-        trackers = Tracker.objects.order_by('name')
-        count = trackers.count()
+        filter_param = request.GET.get('q', None)
+        if filter_param is not None:
+            trackers = Tracker.objects.filter(name__contains=filter_param)
+        else:
+            trackers = Tracker.objects
 
+        trackers = trackers.order_by('name')
+        count = trackers.count()
         paginator = Paginator(trackers, 20)
         page = request.GET.get('page', 1)
         trackers = paginator.page(page)

--- a/etip/trackers/views.py
+++ b/etip/trackers/views.py
@@ -8,14 +8,15 @@ from trackers.models import Tracker
 
 def index(request):
     try:
-        filter_param = request.GET.get('q', None)
-        if filter_param is not None:
-            trackers = Tracker.objects.filter(name__contains=filter_param)
+        filter_name = request.GET.get('tracker_name', '')
+        if filter_name:
+            trackers = Tracker.objects.filter(name__startswith=filter_name)
         else:
             trackers = Tracker.objects
 
         trackers = trackers.order_by('name')
         count = trackers.count()
+
         paginator = Paginator(trackers, 20)
         page = request.GET.get('page', 1)
         trackers = paginator.page(page)
@@ -24,7 +25,8 @@ def index(request):
 
     return render(request, 'tracker_list.html', {
         'trackers': trackers,
-        'count': count
+        'count': count,
+        'filter_name': filter_name
     })
 
 


### PR DESCRIPTION
This PR adds the possibility of searching trackers by name. The text field and buttons are added on the top of the trackers list. 

<img width="593" alt="image" src="https://user-images.githubusercontent.com/1569386/56311231-cfe86200-614d-11e9-9285-71ebfe1919dc.png">

I've  decided to go on the simplest way to do it, even if the page needs to be reloaded. Don't hesitate if that was not the expected, or if some changes are needed ! :)

Fixes #9 