### PR TITLE
Added command to get diff with Exodus platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,15 @@ python manage.py createsuperuser
 export DJANGO_SETTINGS_MODULE=etip.settings.dev
 python manage.py runserver
 ```
+
+### Useful commands
+Some admin commands are available to help administrate the ETIP database.
+
+#### Compare with Exodus
+This command retrieves trackers data from an Exodus instance and looks for differences with trackers in the local database.
+```commandline
+python manage.py compare_with_exodus
+```
+Note: for now, it only compares with local trackers having the flag `is_in_exodus`.
+
+The default Exodus instance queried is the public one available at https://reports.exodus-privacy.eu.org (see `--exodus-hostname` parameter).

--- a/etip/trackers/management/commands/compare_with_exodus.py
+++ b/etip/trackers/management/commands/compare_with_exodus.py
@@ -1,0 +1,144 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.db.models import Q
+from functools import reduce
+import operator
+import requests
+
+from trackers.models import Tracker
+
+EXODUS_API_DEFAULT_HOSTNAME = 'https://reports.exodus-privacy.eu.org'
+EXODUS_API_PATH = '/api/trackers'
+FIELDS_TO_SEARCH = [
+    'name',
+    'code_signature'
+]
+FIELDS_TO_COMPARE = [
+    'name',
+    'code_signature',
+    'network_signature',
+    'website'
+]
+FOUND_AND_IDENTICAL = 'FOUND_AND_IDENTICAL'
+FOUND_BUT_DIFFERENT = 'FOUND_BUT_DIFFERENT'
+MULTIPLE_FOUND = 'MULTIPLE_MATCHES_FOUND_IN_ETIP'
+NOT_FOUND = 'NOT_FOUND_IN_ETIP'
+
+
+class Command(BaseCommand):
+    help = 'Compare trackers stored in Exodus with trackers from ETIP DB'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-e',
+            '--exodus-hostname',
+            type=str,
+            nargs='?',
+            default=EXODUS_API_DEFAULT_HOSTNAME,
+            help='Specify the Hostname of the Exodus instance to query.' +
+            ' Default is public instance of Exodus reports.',
+        )
+        parser.add_argument(
+            '-q',
+            '--quiet',
+            action='store_true',
+            default=False,
+            help='Hide details of differences when tracker is ' +
+            'found but different'
+        )
+
+    def handle(self, *args, **options):
+        exodus_trackers = self.get_all_from_exodus(options['exodus_hostname'])
+        self.stdout.write(
+            'Retrieved {} trackers from Exodus'.format(len(exodus_trackers))
+        )
+        self.count_etip_trackers()
+        self.lookup_trackers(exodus_trackers, options['quiet'])
+
+    def get_diff_fields(self, exodus_tracker, etip_tracker):
+        diff_fields = []
+        for field in FIELDS_TO_COMPARE:
+            if getattr(etip_tracker, field) != exodus_tracker.get(field):
+                diff_fields.append(field)
+        return diff_fields
+
+    def build_query(self, tracker_details):
+        filters = []
+        for field in FIELDS_TO_SEARCH:
+            args = {field + '__exact': tracker_details.get(field)}
+            filters.append(Q(**args))
+        return reduce(operator.or_, filters)
+
+    def display_diff(self, diff_fields, exodus_tracker, etip_tracker):
+        for field in diff_fields:
+            self.stdout.write('[{}]'.format(field))
+            self.stdout.write('etip  : {}'.format(
+                getattr(etip_tracker, field)
+            ))
+            self.stdout.write('exodus: {}'.format(
+                exodus_tracker.get(field)
+            ))
+
+    def find_etip_tracker(self, tracker_details, is_quiet):
+        search_filters = self.build_query(tracker_details)
+        try:
+            etip_tracker = Tracker.objects.exclude(
+                is_in_exodus=False
+            ).get(search_filters)
+        except MultipleObjectsReturned:
+            if not is_quiet:
+                self.stdout.write('{} - {}'.format(
+                    MULTIPLE_FOUND, tracker_details.get('name'))
+                )
+            return MULTIPLE_FOUND
+        except ObjectDoesNotExist:
+            if not is_quiet:
+                self.stdout.write('{} - {}'.format(
+                    NOT_FOUND, tracker_details.get('name'))
+                )
+            return NOT_FOUND
+        diff_fields = self.get_diff_fields(tracker_details, etip_tracker)
+        if (len(diff_fields) == 0):
+            return FOUND_AND_IDENTICAL
+        else:
+            if not is_quiet:
+                self.stdout.write('{} - {}'.format(
+                    FOUND_BUT_DIFFERENT, tracker_details.get('name'))
+                )
+                self.display_diff(diff_fields, tracker_details, etip_tracker)
+            return FOUND_BUT_DIFFERENT
+
+    def lookup_trackers(self, exodus_trackers, is_quiet):
+        result_counters = {
+            FOUND_AND_IDENTICAL: 0,
+            FOUND_BUT_DIFFERENT: 0,
+            MULTIPLE_FOUND: 0,
+            NOT_FOUND: 0
+        }
+        self.stdout.write('Starting case-sensitive lookup...')
+        for id, tracker_details in exodus_trackers.items():
+            lookup_result = self.find_etip_tracker(tracker_details, is_quiet)
+            result_counters[lookup_result] += 1
+        self.stdout.write('Lookup results:')
+        for type in result_counters:
+            self.stdout.write('** {}: {}'.format(type, result_counters[type]))
+
+    def get_all_from_exodus(self, exodus_base_url):
+        response = requests.get(exodus_base_url + EXODUS_API_PATH)
+        if response.status_code != 200:
+            raise CommandError(
+                'Unexpected status from API: {}'
+                .format(response.status_code)
+            )
+        resp = response.json()
+        if resp is None or resp.get('trackers') is None:
+            raise CommandError('Empty response')
+        return resp.get('trackers')
+
+    def count_etip_trackers(self):
+        nb_of_trackers = Tracker.objects.filter(is_in_exodus=True).count()
+        self.stdout.write(
+            'Found {} trackers in ETIP DB expected to be in Exodus'.format(
+                nb_of_trackers
+            )
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
+certifi==2019.3.9
+chardet==3.0.4
 Django~=2.0.3
-django-reversion==2.0.13
 django-bootstrap3==9.1.0
+django-reversion==2.0.13
 gunicorn==19.7.1
+idna==2.8
+pytz==2019.1
+requests==2.21.0
+urllib3==1.24.1


### PR DESCRIPTION
Related to https://github.com/Exodus-Privacy/etip/issues/17

Adds a `compare_with_exodus` command that gets trackers from the Exodus API, then compare them with the local trackers database having `is_in_exodus = True`

Running it on a fresh install with trackers, it logs:
```
Retrieved 195 trackers from Exodus
Found 195 trackers in ETIP DB expected to be in Exodus
[...]
Lookup results:
** FOUND_AND_IDENTICAL: 147
** FOUND_BUT_DIFFERENT: 0
** MULTIPLE_MATCHES_FOUND_IN_ETIP: 48
** NOT_FOUND_IN_ETIP: 0
```

WIP because:
- [x] I'll add some more tests soon and refactor them a bit
- [x] Update doc/readme
- [x] Question (@simpnu?): is it ok for you to do case-insensitive compare ?
- [x] Need to `--autosquash` PR

But you can start reviewing & commenting @simpnu :)
Especially the requirements part, in which I might be pushing too much stuff...