### PR TITLE
feat(code_signature): add regex validation

### DIFF
--- a/etip/trackers/models.py
+++ b/etip/trackers/models.py
@@ -2,6 +2,7 @@ import re
 import uuid
 
 from django.db import models
+from django.core.exceptions import ValidationError
 
 
 class Category(models.Model):
@@ -70,6 +71,15 @@ class Tracker(models.Model):
 
     def __str__(self):
         return self.name
+
+    def clean_fields(self, exclude=None):
+        super().clean_fields(exclude=exclude)
+        try:
+            re.compile(self.code_signature)
+        except re.error:
+            raise ValidationError(
+                {'code_signature': "Must be a valid regex."}
+            )
 
     def code_signature_collision(self):
         collisions = []


### PR DESCRIPTION
This commit is a first step for issue #13 

It's a validation on the `code_signature` field to avoid new errors on trackers list like `nothing to repeat at position 0` for a regex like this one: 

![Screenshot_20190602_184728](https://user-images.githubusercontent.com/1569386/58764421-03007c80-8567-11e9-9c3d-78f7f1db609d.png) 

Feel free if there are things to change ! :)