### PR TITLE
feat(trackers): add only_collisions option

### DIFF
--- a/etip/trackers/models.py
+++ b/etip/trackers/models.py
@@ -81,35 +81,35 @@ class Tracker(models.Model):
                 {'code_signature': "Must be a valid regex."}
             )
 
-    def any_signature_collision(self):
+    def has_any_signature_collision(self):
         trackers = Tracker.objects.all().exclude(id=self.id)
         for t in trackers:
-            if self.__same_code_signature(t) \
-                    or self.__same_network_signature(t):
+            if self._has_same_code_signature(t) \
+                    or self._has_same_network_signature(t):
                 return True
         return False
 
-    def code_signature_collision(self):
+    def get_trackers_with_code_signature_collision(self):
         collisions = []
         trackers = Tracker.objects.all().exclude(id=self.id)
         for t in trackers:
-            if self.__same_code_signature(t):
+            if self._has_same_code_signature(t):
                 collisions.append(t.name)
         return collisions
 
-    def network_signature_collision(self):
+    def get_trackers_with_network_signature_collision(self):
         collisions = []
         trackers = Tracker.objects.all().exclude(id=self.id)
         for t in trackers:
-            if self.__same_network_signature(t):
+            if self._has_same_network_signature(t):
                 collisions.append(t.name)
         return collisions
 
-    def __same_network_signature(self, tracker):
+    def _has_same_network_signature(self, tracker):
         return re.search(self.network_signature, tracker.network_signature) \
             and len(self.network_signature) > self.MIN_SIGNATURE_SIZE
 
-    def __same_code_signature(self, tracker):
+    def _has_same_code_signature(self, tracker):
         return re.search(self.code_signature, tracker.code_signature) \
             and len(self.code_signature) > self.MIN_SIGNATURE_SIZE
 

--- a/etip/trackers/models.py
+++ b/etip/trackers/models.py
@@ -81,12 +81,19 @@ class Tracker(models.Model):
                 {'code_signature': "Must be a valid regex."}
             )
 
+    def any_signature_collision(self):
+        trackers = Tracker.objects.all().exclude(id=self.id)
+        for t in trackers:
+            if self.__same_code_signature(t) \
+                    or self.__same_network_signature(t):
+                return True
+        return False
+
     def code_signature_collision(self):
         collisions = []
         trackers = Tracker.objects.all().exclude(id=self.id)
         for t in trackers:
-            if re.search(self.code_signature, t.code_signature) \
-                    and len(self.code_signature) > self.MIN_SIGNATURE_SIZE:
+            if self.__same_code_signature(t):
                 collisions.append(t.name)
         return collisions
 
@@ -94,10 +101,17 @@ class Tracker(models.Model):
         collisions = []
         trackers = Tracker.objects.all().exclude(id=self.id)
         for t in trackers:
-            if re.search(self.network_signature, t.network_signature) \
-                    and len(self.network_signature) > self.MIN_SIGNATURE_SIZE:
+            if self.__same_network_signature(t):
                 collisions.append(t.name)
         return collisions
+
+    def __same_network_signature(self, tracker):
+        return re.search(self.network_signature, tracker.network_signature) \
+            and len(self.network_signature) > self.MIN_SIGNATURE_SIZE
+
+    def __same_code_signature(self, tracker):
+        return re.search(self.code_signature, tracker.code_signature) \
+            and len(self.code_signature) > self.MIN_SIGNATURE_SIZE
 
     def progress(self):
         p = 0

--- a/etip/trackers/templates/tracker_list.html
+++ b/etip/trackers/templates/tracker_list.html
@@ -6,6 +6,10 @@
             <form class="form-inline" method="get">
                 <label class="sr-only" for="inlineFormTrackerName">Tracker name:</label>
                 <input type="text" class="form-control mb-2 mr-2 col-3" value="{{ filter_name }}" name="tracker_name" id="inlineFormTrackerName" placeholder="Tracker name">
+                <div class="form-check mb-2 mr-sm-2">
+                  <input type="checkbox" class="form-check-input" id="onlyCollisionCheckbox" name="only_collisions" value="true" {{ only_collisions }}/>
+                  <label class="form-check-label" for="onlyCollisionCheckbox">Only collisions</label>
+                </div>
                 <button type="submit" class="btn btn-primary mb-2 mr-2">Submit</button>
                 <a class="btn btn-info mb-2" href={%url 'trackers:index'%}>Clear filter</a>
             </form>

--- a/etip/trackers/templates/tracker_list.html
+++ b/etip/trackers/templates/tracker_list.html
@@ -60,11 +60,11 @@
                                 </td>
                                 <td>
                                     <code>{{ tracker.code_signature|truncatechars:36 }}</code>
-                                    {% if tracker.code_signature_collision %}
+                                    {% if tracker.get_trackers_with_code_signature_collision %}
                                         <div class="alert alert-warning">
                                             <strong>⚠️</strong> collision detected with:
                                             <ul>
-                                                {% for c in tracker.code_signature_collision %}
+                                                {% for c in tracker.get_trackers_with_code_signature_collision %}
                                                     <li>{{ c }}</li>
                                                 {% endfor %}
                                             </ul>
@@ -75,11 +75,11 @@
                                 </td>
                                 <td>
                                     <code>{{ tracker.network_signature|truncatechars:36 }}</code>
-                                    {% if tracker.network_signature_collision %}
+                                    {% if tracker.get_trackers_with_network_signature_collision %}
                                         <div class="alert alert-warning">
                                             <strong>⚠️</strong> collision detected with:
                                             <ul>
-                                                {% for c in tracker.network_signature_collision %}
+                                                {% for c in tracker.get_trackers_with_network_signature_collision %}
                                                     <li>{{ c }}</li>
                                                 {% endfor %}
                                             </ul>

--- a/etip/trackers/templates/tracker_list.html
+++ b/etip/trackers/templates/tracker_list.html
@@ -7,7 +7,7 @@
                 <label class="sr-only" for="inlineFormTrackerName">Tracker name:</label>
                 <input type="text" class="form-control mb-2 mr-2 col-3" value="{{ filter_name }}" name="tracker_name" id="inlineFormTrackerName" placeholder="Tracker name">
                 <div class="form-check mb-2 mr-sm-2">
-                  <input type="checkbox" class="form-check-input" id="onlyCollisionCheckbox" name="only_collisions" value="true" {{ only_collisions }}/>
+                  <input type="checkbox" class="form-check-input" id="onlyCollisionCheckbox" name="only_collisions" {{ only_collisions }}/>
                   <label class="form-check-label" for="onlyCollisionCheckbox">Only collisions</label>
                 </div>
                 <button type="submit" class="btn btn-primary mb-2 mr-2">Submit</button>

--- a/etip/trackers/tests.py
+++ b/etip/trackers/tests.py
@@ -415,6 +415,28 @@ class IndexTrackerListViewTests(TestCase):
     def test_with_results_and_paginate(self):
         for i in range(0, 25):
             Tracker(
+                name='AcTracker_name'
+            ).save()
+
+        for i in range(0, 10):
+            Tracker(
+                name='AbTracker_name'
+            ).save()
+
+        c = Client()
+        response = c.get(
+            '/',
+            {'tracker_name': 'Ac', 'page': 2}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Ab')
+        self.assertEqual(response.context['count'], 25)
+        self.assertEqual(len(response.context['trackers']), 5)
+
+
+    def test_with_all_filters_and_paginate(self):
+        for i in range(0, 25):
+            Tracker(
                 name='AcTracker_name',
                 code_signature='toto.com'
             ).save()

--- a/etip/trackers/tests.py
+++ b/etip/trackers/tests.py
@@ -54,7 +54,7 @@ class TrackerModelTests(TestCase):
             code_signature="toto.com",
         )
         new_tracker.save()
-        self.assertEquals(new_tracker.any_signature_collision(), True)
+        self.assertEquals(new_tracker.has_any_signature_collision(), True)
 
     def test_any_signature_collision_with_network_signature_one(self):
         existing_tracker = Tracker(
@@ -68,7 +68,7 @@ class TrackerModelTests(TestCase):
             network_signature="toto.com",
         )
         new_tracker.save()
-        self.assertEquals(new_tracker.any_signature_collision(), True)
+        self.assertEquals(new_tracker.has_any_signature_collision(), True)
 
     def test_any_signature_collision_containing_network_signature_one(self):
         existing_tracker = Tracker(
@@ -82,7 +82,7 @@ class TrackerModelTests(TestCase):
             network_signature="toto.com",
         )
         new_tracker.save()
-        self.assertEquals(new_tracker.any_signature_collision(), True)
+        self.assertEquals(new_tracker.has_any_signature_collision(), True)
 
     def test_any_signature_collision_without_collisions(self):
         existing_tracker = Tracker(
@@ -98,7 +98,7 @@ class TrackerModelTests(TestCase):
             code_signature="tata.com"
         )
         new_tracker.save()
-        self.assertEquals(new_tracker.any_signature_collision(), False)
+        self.assertEquals(new_tracker.has_any_signature_collision(), False)
 
     def test_code_collision_different_signature(self):
         existing_tracker = Tracker(
@@ -112,7 +112,7 @@ class TrackerModelTests(TestCase):
             code_signature="tutu.com",
         )
         new_tracker.save()
-        collisions = new_tracker.code_signature_collision()
+        collisions = new_tracker.get_trackers_with_code_signature_collision()
         self.assertEquals(collisions, [])
 
     def test_code_collision_same_signature(self):
@@ -129,7 +129,7 @@ class TrackerModelTests(TestCase):
             code_signature=signature,
         )
         new_tracker.save()
-        collisions = new_tracker.code_signature_collision()
+        collisions = new_tracker.get_trackers_with_code_signature_collision()
         self.assertEquals(collisions, [existing_tracker_name])
 
     def test_network_collision_same_signature(self):
@@ -146,7 +146,7 @@ class TrackerModelTests(TestCase):
             network_signature=signature,
         )
         new_tracker.save()
-        collisions = new_tracker.network_signature_collision()
+        collisions = new_tracker.get_trackers_with_network_signature_collision()
         self.assertEquals(collisions, [existing_tracker_name])
 
     def test_network_collision_contains_signature(self):
@@ -163,7 +163,7 @@ class TrackerModelTests(TestCase):
             network_signature=signature,
         )
         new_tracker.save()
-        collisions = new_tracker.network_signature_collision()
+        collisions = new_tracker.get_trackers_with_network_signature_collision()
         self.assertEquals(collisions, [existing_tracker_name])
 
     def test_code_collision_contains_signature(self):
@@ -180,7 +180,7 @@ class TrackerModelTests(TestCase):
             code_signature=signature,
         )
         new_tracker.save()
-        collisions = new_tracker.code_signature_collision()
+        collisions = new_tracker.get_trackers_with_code_signature_collision()
         self.assertEquals(collisions, [existing_tracker_name])
 
     def test_code_collision_multiple_matches(self):
@@ -203,7 +203,7 @@ class TrackerModelTests(TestCase):
             code_signature=signature,
         )
         new_tracker.save()
-        collisions = new_tracker.code_signature_collision()
+        collisions = new_tracker.get_trackers_with_code_signature_collision()
         self.assertEquals(
             collisions, [existing_tracker1_name, existing_tracker2_name])
 
@@ -227,7 +227,7 @@ class TrackerModelTests(TestCase):
             network_signature=signature,
         )
         new_tracker.save()
-        collisions = new_tracker.network_signature_collision()
+        collisions = new_tracker.get_trackers_with_network_signature_collision()
         self.assertEquals(
             collisions, [existing_tracker1_name, existing_tracker2_name])
 

--- a/etip/trackers/views.py
+++ b/etip/trackers/views.py
@@ -9,13 +9,20 @@ from trackers.models import Tracker
 def index(request):
     try:
         filter_name = request.GET.get('tracker_name', '')
+        only_collisions = request.GET.get('only_collisions', False)
         if filter_name:
             trackers = Tracker.objects.filter(name__startswith=filter_name)
         else:
             trackers = Tracker.objects
 
         trackers = trackers.order_by('name')
-        count = trackers.count()
+
+        if only_collisions:
+            trackers = list(
+                t for t in trackers if t.any_signature_collision()
+            )
+
+        count = len(trackers)
 
         paginator = Paginator(trackers, 20)
         page = request.GET.get('page', 1)
@@ -26,7 +33,8 @@ def index(request):
     return render(request, 'tracker_list.html', {
         'trackers': trackers,
         'count': count,
-        'filter_name': filter_name
+        'filter_name': filter_name,
+        'only_collisions': 'checked' if only_collisions else ''
     })
 
 

--- a/etip/trackers/views.py
+++ b/etip/trackers/views.py
@@ -19,7 +19,7 @@ def index(request):
 
         if only_collisions:
             trackers = list(
-                t for t in trackers if t.any_signature_collision()
+                t for t in trackers if t.has_any_signature_collision()
             )
 
         count = len(trackers)


### PR DESCRIPTION
This adds a new filter `only collisions` which works with the name filter too. It's a little checkbox: 

![Screenshot_20190603_221924](https://user-images.githubusercontent.com/1569386/58831788-c3f92680-864d-11e9-97a5-76fcfca1c1e9.png)

As it works like the filter name, the form needs to be submit and it can be cleared too.

I've make some refactor to reuse code to detect code and network collisions. I've added one method which returns when it find one collision for a specific tracker for performance purpose. It can still be a little bit slow (around 3s), and it will depend on the position of each collisions.


I think it can close #37 :)

