### PR TITLE
Add Category column to trackers admin page

### DIFF
--- a/etip/trackers/admin.py
+++ b/etip/trackers/admin.py
@@ -9,8 +9,11 @@ from trackers.models import \
 class TrackerModelAdmin(VersionAdmin):
     date_hierarchy = 'created'
     search_fields = ['name']
-    list_display = ('name', 'code_signature', 'is_in_exodus')
+    list_display = ('name', 'code_signature', 'categories', 'is_in_exodus')
     list_filter = ('is_in_exodus',)
+
+    def categories(self, obj):
+        return ", ".join([c.name for c in obj.category.all()])
 
 
 @admin.register(Capability)


### PR DESCRIPTION
Fixes https://github.com/Exodus-Privacy/etip/issues/38

Here you go:
![Screenshot from 2019-10-11 22-25-24](https://user-images.githubusercontent.com/4201782/66682724-20acc380-ec76-11e9-840e-eb12253d2702.png)