### PR TITLE
Add new tracker page

### DIFF
--- a/etip/trackers/models.py
+++ b/etip/trackers/models.py
@@ -73,6 +73,12 @@ class Tracker(models.Model):
     def __str__(self):
         return self.name
 
+    def get_fields(self):
+        return [
+            (field.name, field.value_to_string(self))
+            for field in Tracker._meta.fields
+        ]
+
     def clean_fields(self, exclude=None):
         super().clean_fields(exclude=exclude)
         try:

--- a/etip/trackers/templates/tracker.html
+++ b/etip/trackers/templates/tracker.html
@@ -1,0 +1,36 @@
+{% extends "base.html"%}
+{% load markdown_extras %}
+{% block content %}
+<div class="row justify-content-md-center">
+  <div class="col-xl-10 col-12">
+    <p>
+      <a class="btn btn-primary" href="/admin/trackers/tracker/{{ tracker.id }}/change/">🖋️ EDIT TRACKER</a>
+    </p>
+
+    {% if tracker.get_trackers_with_network_signature_collision or tracker.get_trackers_with_code_signature_collision %}
+      <div class="alert alert-warning">
+        <strong>⚠️</strong> <b>Collision detected</b> with:
+        <ul>
+          {% for c in tracker.get_trackers_with_network_signature_collision %}
+            <li>{{ c }} (network signature)</li>
+          {% endfor %}
+          {% for c in tracker.get_trackers_with_code_signature_collision %}
+            <li>{{ c }} (code signature)</li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+
+    <table class="table table-bordered table-striped">
+      {% for name, value in tracker.get_fields %}
+        {% if value %}
+          <tr>
+            <th class="text-uppercase">{{ name }}</th>
+            <td>{% if name == "description" %}{{ value | markdown | safe }}{% else %}{{ value }}{% endif %}</td>
+          </tr>
+        {% endif %}
+      {% endfor %}
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/etip/trackers/templates/tracker_list.html
+++ b/etip/trackers/templates/tracker_list.html
@@ -41,8 +41,8 @@
           {% for tracker in trackers %}
             <tr>
               <td>
-                <a href="/admin/trackers/tracker/{{ tracker.id }}/change/">
-                  <strong>🖊️ {{ tracker.name }}</strong>
+                <a href="{% url 'trackers:display_tracker' tracker.id %}">
+                  <strong>{{ tracker.name }}</strong>
                 </a>
                 <div class="progress">
                   <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: {{ tracker.progress }}%"

--- a/etip/trackers/templatetags/markdown_extras.py
+++ b/etip/trackers/templatetags/markdown_extras.py
@@ -1,0 +1,12 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+import markdown as md
+
+register = template.Library()
+
+
+@register.filter()
+@stringfilter
+def markdown(value):
+    return md.markdown(value, extensions=['markdown.extensions.fenced_code'])

--- a/etip/trackers/urls.py
+++ b/etip/trackers/urls.py
@@ -5,5 +5,6 @@ from . import views
 app_name = 'trackers'
 urlpatterns = [
     path('', views.index, name='index'),
+    path('trackers/<id>/', views.display_tracker, name='display_tracker'),
     path('trackers/export', views.export_tracker_list, name='export')
 ]

--- a/etip/trackers/views.py
+++ b/etip/trackers/views.py
@@ -2,8 +2,9 @@ from django.http import JsonResponse
 from django.http.response import Http404
 from django.core.paginator import Paginator
 from django.shortcuts import render
+from django.core.exceptions import ValidationError
 
-from trackers.models import Tracker
+from .models import Tracker
 
 
 def index(request):
@@ -36,6 +37,15 @@ def index(request):
         'filter_name': filter_name,
         'only_collisions': 'checked' if only_collisions else ''
     })
+
+
+def display_tracker(request, id):
+    try:
+        tracker = Tracker.objects.get(pk=id)
+    except (Tracker.DoesNotExist, ValidationError):
+        raise Http404("Tracker does not exist")
+
+    return render(request, 'tracker.html', {'tracker': tracker})
 
 
 def export_tracker_list(request):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ django-reversion==3.0.5
 djangorestframework==3.11.0
 gunicorn==19.7.1
 idna==2.8
+Markdown==3.1.1
 pytz==2019.1
 requests==2.22.0
 sqlparse==0.3.0


### PR DESCRIPTION
Adds a very simple page to display information about a tracker without being logged in
For now it displays every field indifferently, except for the description for which it interprets the markdown language

**This is a MVP, lots of possible improvements over time**

URL is set to `/trackers/<id>` and can be accessed from home page when clicking on a tracker's name

**Example:**
![image](https://user-images.githubusercontent.com/6069449/71766410-28d87000-2f00-11ea-8597-374f28bf3073.png)

**With collision:**
![image](https://user-images.githubusercontent.com/6069449/71766433-51f90080-2f00-11ea-971b-fb9dd403f39b.png)
