### PR TITLE
add Maven fields to the API (closes #63)

### DIFF
--- a/etip/restful_api/serializers.py
+++ b/etip/restful_api/serializers.py
@@ -20,6 +20,10 @@ class TrackerSerializer(serializers.ModelSerializer):
           'is_in_exodus',
           'code_signature',
           'network_signature',
-          'website'
+          'website',
+          'maven_repository',
+          'group_id',
+          'artifact_id',
+          'gradle',
         ]
         depth = 1

--- a/etip/restful_api/tests.py
+++ b/etip/restful_api/tests.py
@@ -34,6 +34,10 @@ class RestfulApiGetAllTrackersTests(APITestCase):
             network_signature='tracker1.com',
             website='https://tracker1.com',
             is_in_exodus=True,
+            maven_repository='https://jcenter.bintray.com/',
+            group_id='com.tracker1',
+            artifact_id='tracker',
+            gradle='com.tracker1:tracker:1.2.3',
         )
 
         category1 = TrackerCategory.objects.create(name='Ads')
@@ -48,7 +52,11 @@ class RestfulApiGetAllTrackersTests(APITestCase):
             'network_signature': 'tracker1.com',
             'website': 'https://tracker1.com',
             'is_in_exodus': True,
-            'category': [{'name': 'Ads'}, {'name': 'Location'}]
+            'category': [{'name': 'Ads'}, {'name': 'Location'}],
+            'maven_repository': 'https://jcenter.bintray.com/',
+            'group_id': 'com.tracker1',
+            'artifact_id': 'tracker',
+            'gradle': 'com.tracker1:tracker:1.2.3',
         }]
 
         response = self.client.get(self.TRACKERS_PATH)


### PR DESCRIPTION
F-Droid and TrackingTheTrackers both need to track libraries and the repos they come from.  Maven repositories, group ID and artifact ID are a nice, clean standard way to do this.  For us to be able to use them, they need to be exposed in an API somehow.  This exposes those fields in the existing ETIP Trackers API.  Then we can move our own maintenance work to the ETIP database.