### PR TITLE
Remove is_in_exodus field for non Admin users

### DIFF
--- a/etip/trackers/admin.py
+++ b/etip/trackers/admin.py
@@ -20,6 +20,14 @@ class TrackerModelAdmin(VersionAdmin):
     def categories(self, obj):
         return ", ".join([c.name for c in obj.category.all()])
 
+    def get_exclude(self, request, obj=None):
+        excluded = super().get_exclude(request, obj) or []
+
+        if not request.user.is_superuser:
+            return excluded + ['is_in_exodus']
+
+        return excluded
+
 
 @admin.register(Capability)
 class CapabilityModelAdmin(VersionAdmin):


### PR DESCRIPTION
Removes the possibility to change the field `is_in_exodus` if you are not a superuser

![image](https://user-images.githubusercontent.com/6069449/91668808-df343980-eb0f-11ea-8fdd-819904f98af2.png)
