### PR TITLE
feat: Add new fields in trackers export feature

### DIFF
--- a/etip/restful_api/tests.py
+++ b/etip/restful_api/tests.py
@@ -44,7 +44,6 @@ class RestfulApiGetAllTrackersTests(APITestCase):
         category2 = TrackerCategory.objects.create(name='Location')
         tracker.category.add(category1)
         tracker.category.add(category2)
-        self.maxDiff = None
         expected_tracker = [{
             'id': str(tracker.id),
             'name': tracker.name,
@@ -88,7 +87,6 @@ class RestfulApiGetAllTrackersTests(APITestCase):
         category2 = TrackerCategory.objects.create(name='Location')
         tracker.category.add(category1)
         tracker.category.add(category2)
-        self.maxDiff = None
         expected_tracker = [{
             'id': str(tracker.id),
             'name': tracker.name,

--- a/etip/trackers/models.py
+++ b/etip/trackers/models.py
@@ -47,9 +47,6 @@ class Tracker(models.Model):
     MIN_SIGNATURE_SIZE = 4
     MIN_DESCRIPTION_SIZE = 180
     MIN_WEBSITE_SIZE = 3
-    EXPORTABLE_FIELDS = [
-        'name', 'code_signature', 'network_signature', 'website'
-    ]
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created = models.DateTimeField(auto_now_add=True)
@@ -233,6 +230,18 @@ class Tracker(models.Model):
         else:
             documentation_list = []
         return documentation_list
+
+    def serialize(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'code_signature': self.code_signature,
+            'network_signature': self.network_signature,
+            'website': self.website,
+            'category': [c.name for c in self.category.all()],
+            'is_in_exodus': self.is_in_exodus,
+            'documentation': self.documentation_list()
+        }
 
 
 class TrackerApproval(models.Model):

--- a/etip/trackers/tests.py
+++ b/etip/trackers/tests.py
@@ -1009,23 +1009,25 @@ class ExportTrackerListViewTests(TestCase):
             response.content.decode('utf-8'), {'trackers': []})
 
     def test_with_trackers(self):
-        tracker_1 = Tracker(
+        category = TrackerCategory.objects.create(name='analytics')
+        tracker_1 = Tracker.objects.create(
             name='tracker_1',
             code_signature='code_1',
             network_signature='network_1',
-            website='https://website1'
+            website='https://website1',
+            is_in_exodus=True
         )
 
-        tracker_2 = Tracker(
+        tracker_2 = Tracker.objects.create(
             name='tracker_2',
             code_signature='code_2',
             network_signature='network_2',
             website='https://website2',
-            description='description du tracker_2'
+            description='description du tracker_2',
+            documentation="https://toto.com https://toto.com/doc"
         )
 
-        tracker_1.save()
-        tracker_2.save()
+        tracker_1.category.set([category])
 
         c = Client()
         response = c.get('/trackers/export')
@@ -1036,16 +1038,27 @@ class ExportTrackerListViewTests(TestCase):
         expected_json = {
             'trackers': [
                 {
+                    'id': str(tracker_1.id),
                     'name': tracker_1.name,
                     'code_signature': tracker_1.code_signature,
                     'network_signature': tracker_1.network_signature,
-                    'website': tracker_1.website
+                    'website': tracker_1.website,
+                    'documentation': [],
+                    'category': ['analytics'],
+                    'is_in_exodus': tracker_1.is_in_exodus
                 },
                 {
+                    'id': str(tracker_2.id),
                     'name': tracker_2.name,
                     'code_signature': tracker_2.code_signature,
                     'network_signature': tracker_2.network_signature,
-                    'website': tracker_2.website
+                    'website': tracker_2.website,
+                    'documentation': [
+                        'https://toto.com',
+                        'https://toto.com/doc'
+                    ],
+                    'category': [],
+                    'is_in_exodus': tracker_2.is_in_exodus
                 }
             ]
         }

--- a/etip/trackers/views.py
+++ b/etip/trackers/views.py
@@ -119,7 +119,7 @@ def approved(request):
 
 def export_tracker_list(request):
     trackers = Tracker.objects.order_by('name')
-    trackers_list = list(trackers.values(*Tracker.EXPORTABLE_FIELDS))
+    trackers_list = [tracker.serialize() for tracker in trackers]
     response = JsonResponse(dict(trackers=trackers_list))
     response['Content-Disposition'] = 'attachment; filename=trackers.json'
     return response


### PR DESCRIPTION
Fixes #126 

Not all fields are exposed but the most important ones are added: `id`, `category`, `documentation`, `is_in_exodus`