### PR TITLE
[CI] Add Python 3.12 and 3.13 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
         python-version:
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
# Goal

- Add Python `3.12` and `3.13` CI tests